### PR TITLE
[fix] (common) Fix OS detection to be independent on the entity order in /etc/os-release

### DIFF
--- a/bigtop-manager-common/src/main/java/org/apache/bigtop/manager/common/utils/os/OSDetection.java
+++ b/bigtop-manager-common/src/main/java/org/apache/bigtop/manager/common/utils/os/OSDetection.java
@@ -69,16 +69,13 @@ public class OSDetection {
 
 
     private static String regexOS(Pattern pattern, String content) {
-        Matcher matcher = pattern.matcher(content);
-        if (matcher.find()) {
-            try {
+        for (String line : content.split("\\n", -1)) {
+            Matcher matcher = pattern.matcher(line);
+            if (matcher.matches()) {
                 return matcher.group(1);
-            } catch (Exception e) {
-                throw new RuntimeException("Unable to find OS: " + content, e);
             }
-        } else {
-            throw new RuntimeException("Unable to find OS: " + content);
         }
+        throw new RuntimeException("Unable to find OS: " + content);
     }
 
 


### PR DESCRIPTION
I tried to execute the existing tests and ran into the following error:

```
$ ./mvnw clean install

...

[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 2.092 s <<< FAILURE! - in org.apache.bigtop.manager.agent.AgentApplicationTests                                                                                           

...

Caused by: java.lang.RuntimeException: Unsupported OS: [2222]
```

This is because VERSION_ID is defined before ID in my /etc/os-release and the current detection system recognizes the former as the OS name.

```
$ cat /etc/os-release
PRETTY_NAME="Ubuntu 22.04.3 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04.3 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu

...
```

This PR modifies the regexOS method to fix this problem by using `Matcher.matches()` instead of `Matcher.find()`.