### PR TITLE
[fix] (server) Fix o.a.b.manager.server.ServerApplicationTests to work

### DIFF
--- a/bigtop-manager-server/src/test/java/org/apache/bigtop/manager/server/ServerApplicationTests.java
+++ b/bigtop-manager-server/src/test/java/org/apache/bigtop/manager/server/ServerApplicationTests.java
@@ -3,7 +3,7 @@ package org.apache.bigtop.manager.server;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class ServerApplicationTests {
 
     @Test


### PR DESCRIPTION
After addressing #70, I came across another problem, even if there was a MySQL instance with the bigtop_manager database for the test:

```
$ ./mvnw clean install

...

Caused by: java.lang.IllegalStateException: Attribute 'jakarta.websocket.server.ServerContainer' not found in ServletContext                                                                  
        at org.springframework.util.Assert.state(Assert.java:76)                                                                                                                              
        at org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean.afterPropertiesSet(ServletServerContainerFactoryBean.java:117)                                    
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1816)                                       
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1766)                                          
        ... 88 common frames omitted                                                                                                                                                          
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 4.899 s <<< FAILURE! - in org.apache.bigtop.manager.server.ServerApplicationTests                                     
```

According to [this post](https://stackoverflow.com/questions/56065309/attribute-servercontainer-not-found-in-servletcontext#answer-56073109), adding the `@SpringBootTest` annotation to the test class or using `WebEnviroment` other than `MOCK` or `NONE` seems to resolve this problem.