### PR TITLE
[Improvement] (ci) Add JDK 21 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: ['17', '21']
     services:
       db:
         image: mysql:8.0
@@ -16,5 +20,6 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
-      - run: ./mvnw clean install -B
+          java-version: ${{ matrix.java }}
+          cache: 'maven'
+      - run: ./mvnw clean install -B -Djava.version=${{ matrix.java }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Bigtop-Manager is a platform for managing Bigtop components.
 
 ## Development
 
-Requires JDK 17
+Requires JDK 17 or 21
 
 ### API-DOCS
 [swagger-ui](http://localhost:8080/swagger-ui/index.html)

--- a/bigtop-manager-bom/pom.xml
+++ b/bigtop-manager-bom/pom.xml
@@ -67,6 +67,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.mapstruct</groupId>
                 <artifactId>mapstruct</artifactId>
                 <version>${mapstruct.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
 
         <mapstruct.version>1.5.5.Final</mapstruct.version>
-        <lombok.version>1.18.26</lombok.version>
+        <lombok.version>1.18.30</lombok.version>
         <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
     </properties>
 


### PR DESCRIPTION
[Lombok started to support Java 21 since 1.18.30](https://github.com/projectlombok/lombok/issues/3393#issuecomment-1726803191). Let's upgrade it and ensure our codebase can be built against Java 21 in CI.
This PR also introduces cache mechanism so that we can accelerate the CI cycle.