### PR TITLE
[improvement] (dist) Exclude assembly and bin from jar package

### DIFF
--- a/bigtop-manager-agent/pom.xml
+++ b/bigtop-manager-agent/pom.xml
@@ -88,6 +88,8 @@
                     <excludes>
                         <exclude>*.yaml</exclude>
                         <exclude>*.xml</exclude>
+                        <exclude>assembly/</exclude>
+                        <exclude>bin/</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/bigtop-manager-server/pom.xml
+++ b/bigtop-manager-server/pom.xml
@@ -166,6 +166,10 @@
                     <excludes>
                         <exclude>*.yaml</exclude>
                         <exclude>*.xml</exclude>
+                        <exclude>assembly/</exclude>
+                        <exclude>bin/</exclude>
+                        <exclude>ddl/</exclude>
+                        <exclude>stacks/</exclude>
                     </excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
fix: #102 